### PR TITLE
Add Support for Telegram Topic-Specific Messages (message_thread_id)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -662,24 +662,25 @@ send_to_telegram() {
         elif [[ ! "$chat_id" =~ ^-?[0-9]+$ ]]; then
             error "Invalid chat ID format!"
         else
+            input "Enter the message thread ID (Press Enter to skip): " message_thread_id
+
+            log "Checking Telegram bot..."
+            if [ -n "$message_thread_id" ]; then
+                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d message_thread_id="$message_thread_id" -d text="Backuper Test Message!")
+            else
+                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
+            fi
+
+            if [[ "$response" -ne 200 ]]; then
+                error "Invalid bot token, chat ID, message thread ID, or Telegram API error!"
+            else
+                success "Bot token, chat ID, and thread ID (if provided) are valid."
+            fi
             break
         fi
     done
 
-    input "Enter the message thread ID (Press Enter to skip): " message_thread_id
 
-    log "Checking Telegram bot..."
-    if [ -n "$message_thread_id" ]; then
-        response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d message_thread_id="$message_thread_id" -d text="Backuper Test Message!")
-    else
-        response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
-    fi
-
-    if [[ "$response" -ne 200 ]]; then
-        error "Invalid bot token, chat ID, message thread ID, or Telegram API error!"
-    else
-        success "Bot token, chat ID, and thread ID (if provided) are valid."
-    fi
     sleep 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -677,7 +677,6 @@ send_to_telegram() {
 
     if [[ "$response" -ne 200 ]]; then
         error "Invalid bot token, chat ID, message thread ID, or Telegram API error!"
-        exit 1
     else
         success "Bot token, chat ID, and thread ID (if provided) are valid."
     fi

--- a/install.sh
+++ b/install.sh
@@ -642,10 +642,11 @@ send_to() {
 send_to_telegram() {
     clear
     print "[TELEGRAM]\n"
-    print "To use Telegram, you need to provide a bot token and a chat ID.\n"
+    print "To use Telegram, you need to provide a bot token, a chat ID, and optionally, a thread ID.\n"
 
     while true; do
         input "Enter the bot token: " bot_token
+        input "Enter the thread ID (optional, press Enter to skip): " thread_id
         if [[ -z "$bot_token" ]]; then
             error "Bot token cannot be empty!"
         elif [[ ! "$bot_token" =~ ^[0-9]+:[a-zA-Z0-9_-]{35}$ ]]; then
@@ -663,11 +664,21 @@ send_to_telegram() {
             error "Invalid chat ID format!"
         else
             log "Checking Telegram bot..."
+            if [ -n "$thread_id" ]; then
+                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d message_thread_id="$thread_id" -d text="Backuper Test Message!")
+            else
+                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
+            fi
+            error "Chat ID cannot be empty!"
+        elif [[ ! "$chat_id" =~ ^-?[0-9]+$ ]]; then
+            error "Invalid chat ID format!"
+        else
+            log "Checking Telegram bot..."
             response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
             if [[ "$response" -ne 200 ]]; then
                 error "Invalid bot token or chat ID, or Telegram API error!"
             else
-                success "Bot token and chat ID are valid."
+                success "Bot token, chat ID, and optional thread ID are valid."
                 sleep 1
                 break
             fi
@@ -853,8 +864,13 @@ fi
     local send_file_command
     local send_notification_command
     if [ "$send_to_option" == "1" ]; then  # Telegram
-        send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
-        send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
+        if [ -n "$thread_id" ]; then
+            send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"message_thread_id=$thread_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
+            send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"message_thread_id=$thread_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
+        else
+            send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
+            send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
+        fi
         CAPTION_TEXT="${caption} 
 📦 From <code>\${ip}</code> 
 ⚡️ Develop by <b>@ErfJabs</b>"

--- a/install.sh
+++ b/install.sh
@@ -675,12 +675,11 @@ send_to_telegram() {
                 error "Invalid bot token, chat ID, message thread ID, or Telegram API error!"
             else
                 success "Bot token, chat ID, and thread ID (if provided) are valid."
+                sleep 1
+                break
             fi
-            break
         fi
     done
-
-
     sleep 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -137,7 +137,7 @@ menu() {
 }
 
 manage_backups() {
-    local backup_scripts=($(find /root/ -name "*_backuper.sh" -o -name "ac-backup*.sh"))
+    local backup_scripts=($(find /root/ -name "*_backuper*.sh" -o -name "ac-backup*.sh"))
     
     if [ ${#backup_scripts[@]} -eq 0 ]; then
         success "No active backup scripts found."

--- a/install.sh
+++ b/install.sh
@@ -642,11 +642,10 @@ send_to() {
 send_to_telegram() {
     clear
     print "[TELEGRAM]\n"
-    print "To use Telegram, you need to provide a bot token, a chat ID, and optionally, a thread ID.\n"
+    print "To use Telegram, you need to provide a bot token and a chat ID.\n"
 
     while true; do
         input "Enter the bot token: " bot_token
-        input "Enter the thread ID (optional, press Enter to skip): " thread_id
         if [[ -z "$bot_token" ]]; then
             error "Bot token cannot be empty!"
         elif [[ ! "$bot_token" =~ ^[0-9]+:[a-zA-Z0-9_-]{35}$ ]]; then
@@ -664,21 +663,11 @@ send_to_telegram() {
             error "Invalid chat ID format!"
         else
             log "Checking Telegram bot..."
-            if [ -n "$thread_id" ]; then
-                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d message_thread_id="$thread_id" -d text="Backuper Test Message!")
-            else
-                response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
-            fi
-            error "Chat ID cannot be empty!"
-        elif [[ ! "$chat_id" =~ ^-?[0-9]+$ ]]; then
-            error "Invalid chat ID format!"
-        else
-            log "Checking Telegram bot..."
             response=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.telegram.org/bot$bot_token/sendMessage" -d chat_id="$chat_id" -d text="Backuper Test Message!")
             if [[ "$response" -ne 200 ]]; then
                 error "Invalid bot token or chat ID, or Telegram API error!"
             else
-                success "Bot token, chat ID, and optional thread ID are valid."
+                success "Bot token and chat ID are valid."
                 sleep 1
                 break
             fi
@@ -864,13 +853,8 @@ fi
     local send_file_command
     local send_notification_command
     if [ "$send_to_option" == "1" ]; then  # Telegram
-        if [ -n "$thread_id" ]; then
-            send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"message_thread_id=$thread_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
-            send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"message_thread_id=$thread_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
-        else
-            send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
-            send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
-        fi
+        send_file_command="curl -s -F \"chat_id=$chat_id\" -F \"document=@\$file_to_send\" -F \"caption=\$caption\" -F \"parse_mode=HTML\" \"https://api.telegram.org/bot$bot_token/sendDocument\""
+        send_notification_command="curl -s -X POST \"https://api.telegram.org/bot$bot_token/sendMessage\" -d \"chat_id=$chat_id\" -d \"text=\$message\" -d \"parse_mode=HTML\""
         CAPTION_TEXT="${caption} 
 📦 From <code>\${ip}</code> 
 ⚡️ Develop by <b>@ErfJabs</b>"

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ check_needs() {
 menu() {
     while true; do
         print "\n\t Welcome to Backuper!"
-        print "\t\t version 0.2.5 by @ErfJab"
+        print "\t\t version 0.2.6 by @ErfJab"
         print "—————————————————————————————————————————————————————————————————————————"
         print "1) Install"
         print "2) Manage"

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ Backuper is an automated backup script with full customization options and suppo
 - **No annoying ads**
 - **Get a list of active backups**
 - **Ability to stop backups**
+- **Send backups to Telegram thread (topic) of the forum**
 
 ### 📦 Templates
 


### PR DESCRIPTION
Hi, I found it very useful to be able to put backups in a separate topic, added optional support for such a feature.

Also, I noticed that the generated script ends with `*_`, but the `manage_backups()` function looks for `*_backuper.sh`. Thus, it is not possible to use manage. If I am doing something wrong - let me know, I can remove this fix.